### PR TITLE
mm: Fix undeclared oom

### DIFF
--- a/mm/memory.c
+++ b/mm/memory.c
@@ -2871,6 +2871,10 @@ out:
 	if (old_page)
 		put_page(old_page);
 	return ret;
+oom:
+	if (old_page)
+		put_page(old_page);
+	return VM_FAULT_OOM;
 }
 
 /**


### PR DESCRIPTION
../mm/memory.c:2754:9: error: use of undeclared label 'oom'
                        goto oom;
                             ^
Signed-off-by: Tkpointz <pointzztk@gmail.com>